### PR TITLE
make sure value is within range of numeric type

### DIFF
--- a/cxx_argp_parser.h
+++ b/cxx_argp_parser.h
@@ -63,7 +63,7 @@ class parser
 		const auto px = &x;
 		return [px](const char *arg) {
 			char *end;
-			long value = strtol(arg, &end, 0);
+			long long int value = strtoll(arg, &end, 0);
 			if (*end != '\0') // not all of the string has been consumed
 				return false;
 			if (value < std::numeric_limits<T>::min() ||

--- a/cxx_argp_parser.h
+++ b/cxx_argp_parser.h
@@ -53,10 +53,10 @@ class parser
 		};
 	}
 
-	/* for integers */
+	/* for signed integers */
 	template <typename T>
 	typename std::enable_if<
-	    std::numeric_limits<T>::is_integer,
+	    std::numeric_limits<T>::is_integer && std::numeric_limits<T>::is_signed,
 	    std::function<bool(const char *)>>::type
 	make_check_function(T &x)
 	{
@@ -68,6 +68,26 @@ class parser
 				return false;
 			if (value < std::numeric_limits<T>::min() ||
 				value > std::numeric_limits<T>::max())
+				return false;
+			*px = value;
+			return true;
+		};
+	}
+
+	/* for unsigned integers */
+	template <typename T>
+	typename std::enable_if<
+	    std::numeric_limits<T>::is_integer && !std::numeric_limits<T>::is_signed,
+	    std::function<bool(const char *)>>::type
+	make_check_function(T &x)
+	{
+		const auto px = &x;
+		return [px](const char *arg) {
+			char *end;
+			unsigned long long int value = strtoull(arg, &end, 0);
+			if (*end != '\0') // not all of the string has been consumed
+				return false;
+			if (value > std::numeric_limits<T>::max())
 				return false;
 			*px = value;
 			return true;

--- a/cxx_argp_parser.h
+++ b/cxx_argp_parser.h
@@ -63,9 +63,13 @@ class parser
 		const auto px = &x;
 		return [px](const char *arg) {
 			char *end;
-			*px = strtol(arg, &end, 0);
+			long value = strtol(arg, &end, 0);
 			if (*end != '\0') // not all of the string has been consumed
 				return false;
+			if (value < std::numeric_limits<T>::min() ||
+				value > std::numeric_limits<T>::max())
+				return false;
+			*px = value;
 			return true;
 		};
 	}


### PR DESCRIPTION
your existing numeric parsing code doesn't ensure that numeric values are valid for the type. for example, passing 128 to a `char` should cause an error rather than resulting
in success and a value of zero.

happy to add some tests if you think this is a useful change