### PR TITLE
keep options in the order they're inserted

### DIFF
--- a/cxx_argp_parser.h
+++ b/cxx_argp_parser.h
@@ -203,7 +203,7 @@ public:
 	void add_option(const argp_option &o,
 	                const std::function<bool(const char *)> &&custom)
 	{
-		options_.insert(options_.begin(), o);
+		options_.insert(options_.end() - 1, o);
 		convert_.insert(std::make_pair(o.key, custom));
 		counter_.insert(std::make_pair(o.key, 0));
 	}


### PR DESCRIPTION
this helps keep things predictable when using `OPTION_ALIAS` as well as being in-line with the aims of staying similar to the C API

not sure if original behavior is deliberate, I can't see it mentioned in the README... its purpose seems to be maintaining the "NULL" entry at the end, but shuffling everything up seems unnecessary